### PR TITLE
Fix subscribe panic

### DIFF
--- a/internal/exec/packer/packer.go
+++ b/internal/exec/packer/packer.go
@@ -225,8 +225,9 @@ func (p *StructPacker) Pack(value interface{}) (reflect.Value, error) {
 	for _, f := range p.fields {
 		if value, ok := values[f.field.Name.Name]; ok {
 			packed, err := f.fieldPacker.Pack(value)
+
 			if err != nil {
-				return reflect.Value{}, err
+				return reflect.Value{}, fmt.Errorf("field [%s]: %s", f.field.Name.Name, err)
 			}
 			v.Elem().FieldByIndex(f.fieldIndex).Set(packed)
 		}


### PR DESCRIPTION
Handle errs from request after ApplyOperation is executed
Prevent panic when "var f *fieldToExec" is nil
Added field "name" on pack error